### PR TITLE
run php artisan route:cache,route bindings wrong

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -58,8 +58,8 @@ class RouteGroup
     protected static function formatPrefix($new, $old)
     {
         $old = $old['prefix'] ?? null;
-
-        return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+        
+        return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
     }
 
     /**


### PR DESCRIPTION
When I use the route cache, I will get an error with the route binding parameters, so I trace the source code, and modify it here is no problem
![image](https://user-images.githubusercontent.com/20275621/77681675-a926e280-6fd0-11ea-89e9-49f59fd7680d.png)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
